### PR TITLE
fix robotf 'urlopen' by updating pip version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ addons:
     packages:
       - google-chrome-stable
 install:
-  - sudo pip install -r requirements.txt
+  - pip install --upgrade pip
+  - pip -V
+  - pip install -r requirements.txt
 before_script:
   - wget "http://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip"
   - unzip chromedriver_linux64.zip


### PR DESCRIPTION
update travis install step to upade pip version

references:
https://stackoverflow.com/questions/51686224/typeerror-urlopen-got-multiple-values-for-keyword-argument-body-while-execu
https://github.com/travis-ci/travis-ci/issues/4194